### PR TITLE
fix: delete workspace even if connection can not be made

### DIFF
--- a/pkg/provider/destroy.go
+++ b/pkg/provider/destroy.go
@@ -24,20 +24,18 @@ func (p *DigitalOceanProvider) DestroyWorkspace(workspaceReq *provider.Workspace
 	dockerClient, err := p.getDockerClient(workspaceReq.Workspace.Id)
 	if err != nil {
 		logWriter.Write([]byte("Failed to get docker client: " + err.Error() + "\n"))
-		return new(provider_util.Empty), err
-	}
+	} else {
+		sshClient, err := p.getSshClient(workspaceReq.Workspace.Id)
+		if err != nil {
+			logWriter.Write([]byte("Failed to get ssh client: " + err.Error() + "\n"))
+		} else {
+			defer sshClient.Close()
 
-	sshClient, err := p.getSshClient(workspaceReq.Workspace.Id)
-	if err != nil {
-		logWriter.Write([]byte("Failed to get ssh client: " + err.Error() + "\n"))
-		return new(provider_util.Empty), err
-	}
-	defer sshClient.Close()
-
-	err = dockerClient.DestroyWorkspace(workspaceReq.Workspace, p.getWorkspaceDir(workspaceReq.Workspace.Id), sshClient)
-	if err != nil {
-		logWriter.Write([]byte("Failed to destroy workspace: " + err.Error() + "\n"))
-		return new(provider_util.Empty), err
+			err = dockerClient.DestroyWorkspace(workspaceReq.Workspace, p.getWorkspaceDir(workspaceReq.Workspace.Id), sshClient)
+			if err != nil {
+				logWriter.Write([]byte("Failed to destroy workspace: " + err.Error() + "\n"))
+			}
+		}
 	}
 
 	targetOptions, err := types.ParseTargetOptions(workspaceReq.TargetOptions)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -185,7 +185,7 @@ func (p *DigitalOceanProvider) waitForDial(workspaceId string, dialTimeout time.
 	dialStartTime := time.Now()
 	for {
 		if time.Since(dialStartTime) > dialTimeout {
-			return errors.New("timeout: dialing timed out after 3 minutes")
+			return fmt.Errorf("timeout: dialing timed out after %f minutes", dialTimeout.Minutes())
 		}
 
 		dialConn, err := tsnetConn.Dial(context.Background(), "tcp", fmt.Sprintf("%s:%d", workspaceId, config.SSH_PORT))


### PR DESCRIPTION
# Delete Workspace Even if Connection Can Not Be Made

## Description

This PR fixes the scenario where a connection to the workspace can not be made but the user wants to delete the droplet.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
